### PR TITLE
Reorganise the command line to use grouped commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ deploy:
     repo: rjoyal/domain_shared_contacts_client
 env:
 - TOXENV=py27
-- TOXENV=py26
 - TOXENV=pypy
 install: pip install -U tox
 language: python

--- a/README.rst
+++ b/README.rst
@@ -32,20 +32,20 @@ Features
 
     $ pip install domain_shared_contacts_client
     $ domain_shared_contacts_client --help
-    Usage: domain_shared_contacts_client [OPTIONS]
+    Usage: domain_shared_contacts_client [OPTIONS] DOMAIN ADMIN CREDENTIALS
+                                         COMMAND [ARGS]...
 
-      Console script for domain_shared_contacts_client
+      Command line utility to interact with the Shared Contacts API.
 
     Options:
-      --domain TEXT           Your Google Apps domain (e.g. example.com
-      --admin TEXT            Your domain admin account email (e.g.
-                              admin@example.com)
-      --credentials TEXT      JSON credentials for your service account
-      --action TEXT           One of the following actions: list, create, read,
-                              update, delete
-      --contact_details TEXT  A JSON file containing a new contact record
-      --id TEXT               The ID of a contact to read, update or delete
-      --help                  Show this message and exit.
+      --help  Show this message and exit.
+
+    Commands:
+      create  a single contact
+      delete  a single contact
+      list    all contacts
+      read    a single contact
+      update  a single contact
 
 - List, create, read, update and delete basic information for Google Domain Shared Contacts
     - name

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,10 +21,10 @@ Use Google Domain Shared Contacts Client in a project to list, create, read, upd
 Fetch contacts using the CLI::
 
     $ domain_shared_contacts_client \
-        --domain example.com \
-        --admin admin@example.com \
-        --credentials /path/to/client_secret.json \
-        --action list
+        example.com \
+        admin@example.com \
+        /path/to/client_secret.json \
+        list
 
 Example new_contact.json::
 
@@ -67,11 +67,10 @@ Create a new contact::
 Create a new contact using the CLI::
 
     $ domain_shared_contacts_client \
-        --domain example.com \
-        --admin admin@example.com \
-        --credentials /path/to/client_secret.json \
-        --action create \
-        --contact-details /path/to/new_contact.json
+        example.com \
+        admin@example.com \
+        /path/to/client_secret.json \
+        create /path/to/new_contact.json
     {"id": "http://www.google.com/m8/feeds/contacts/example.com/base/2ba2136d0e101978"}
 
 Read a contact::
@@ -82,11 +81,10 @@ Read a contact::
 Read a contact using the CLI::
 
     $ domain_shared_contacts_client \
-        --domain example.com \
-        --admin admin@example.com \
-        --credentials /path/to/client_secret.json \
-        --action read \
-        --id http://www.google.com/m8/feeds/contacts/example.com/base/2ba2136d0e101978
+        example.com \
+        admin@example.com \
+        /path/to/client_secret.json \
+        read 2ba2136d0e101978
 
 Example update_contact.json::
 
@@ -116,12 +114,10 @@ Update a contact::
 Update a contact using the CLI::
 
     $ domain_shared_contacts_client \
-        --domain example.com \
-        --admin admin@example.com \
-        --credentials /path/to/client_secret.json \
-        --action read \
-        --id http://www.google.com/m8/feeds/contacts/example.com/base/2ba2136d0e101978 \
-        --contact-details /path/to/updated_contact.json
+        example.com \
+        admin@example.com \
+        /path/to/client_secret.json \
+        update /path/to/updated_contact.json
 
 Delete a contact::
 
@@ -130,12 +126,11 @@ Delete a contact::
 
 Delete a contact using the CLI::
 
-    $ domain_shared_contacts_client 
-        --domain example.com \
-        --admin admin@example.com \
-        --credentials /path/to/client_secret.json \
-        --action delete \
-        --id http://www.google.com/m8/feeds/contacts/example.com/base/2ba2136d0e101978
+    $ domain_shared_contacts_client
+        example.com \
+        admin@example.com \
+        /path/to/client_secret.json \
+        delete 2ba2136d0e101978
     {"status": "OK"}
 
 This package assumes the following:

--- a/domain_shared_contacts_client/cli.py
+++ b/domain_shared_contacts_client/cli.py
@@ -4,75 +4,112 @@ import json
 import os.path
 
 import click
-
 import contacts_helper
 import domain_shared_contacts_client
 
-actions = ['list', 'create', 'read', 'update', 'delete']
 
-
-def validate_file(ctx, param, value):
+@click.group()
+@click.argument('domain')
+@click.argument('admin')
+@click.argument('credentials', type=click.Path(exists=True))
+@click.pass_context
+def cli(ctx, domain, admin, credentials):
     """
-    Check if the value parameter points to an existing file
-    Use validate_required_file to validate that the parameter is present
+    Command line utility to interact with the Shared Contacts API.
     """
-    if value is None:
-        return None
-    if not os.path.isfile(value):
-        # TODO how to get parameter name in error message
-        raise click.BadParameter('%s should point to a existing file: %s not found' % (param.human_readable_name, value))
-    return value
+    ctx.obj['domain'] = domain
+    ctx.obj['admin'] = admin
+    ctx.obj['credentials'] = credentials
 
 
-def validate_required_file(ctx, param, value):
-    if value is None:
-        raise click.BadParameter('%s are required' % param.human_readable_name)
-    return validate_file(ctx, param, value)
+@cli.command()
+@click.option('--indent', '-i', type=int, default=None)
+@click.option('--sort/--no-sort', default=True)
+@click.option('--output', '-o', type=click.File('w'), default='-')
+@click.pass_context
+def list(ctx, indent, sort, output):
+    """
+    all contacts
+    """
+    client = domain_shared_contacts_client.Client(**ctx.obj)
+    contacts = client.get_contacts()
+    json.dump(contacts, output,
+              default=contacts_helper.convert_contacts,
+              sort_keys=sort, indent=indent)
 
 
-def validate_action(ctx, param, value):
-    """ Check if the action is supported """
-    if value not in actions:
-        raise click.BadParameter('invalid action %s' % value)
-    return value
+@cli.command()
+@click.argument('contact', type=click.Path(exists=True))
+@click.option('--indent', '-i', type=int, default=None)
+@click.option('--sort/--no-sort', default=True)
+@click.option('--output', '-o', type=click.File('w'), default='-')
+@click.pass_context
+def create(ctx, contact, indent, sort, output):
+    """
+    a single contact
+    """
+    client = domain_shared_contacts_client.Client(**ctx.obj)
+    contact = client.create_contact(contact)
+    json.dump(contact, output,
+              default=contacts_helper.convert_contacts,
+              sort_keys=sort, indent=indent)
 
 
-@click.command()
-@click.option('--domain', help='Your Google Apps domain (e.g. example.com')
-@click.option('--admin', help='Your domain admin account email (e.g. admin@example.com)')
-@click.option('--credentials', help='JSON credentials for your service account',
-              callback=validate_required_file)
-@click.option('--action', help='One of the following actions: list, create, read, update, delete',
-              callback=validate_action)
-@click.option('--contact_details', help='A JSON file containing a new contact record',
-              callback=validate_file)
-@click.option('--id', help='The ID of a contact to read, update or delete')
-def main(domain, admin, credentials, action, contact_details, id):
-    """Console script for domain_shared_contacts_client"""
-    client = domain_shared_contacts_client.Client(domain=domain, admin=admin,
-                                                  credentials=credentials)
-    if action == 'list':
-        contacts = client.get_contacts()
-        print(json.dumps(contacts, default=contacts_helper.convert_contacts,
-                         sort_keys=True, indent=4))
-    elif action == 'create':
-        if contact_details is None:
-            raise click.UsageError('Please provide contact_details')
-        saved_contact = client.create_contact(contact_details)
-        print(json.dumps(saved_contact))
-    elif action == 'read':
-        contact = client.read_contact(id)
-        print(json.dumps(contact, default=contacts_helper.convert_contact,
-                         sort_keys=True, indent=4))
-    elif action == 'update':
-        if contact_details is None:
-            raise click.UsageError('Please provide contact_details')
-        contact = client.update_contact(id, contact_details)
-        print(json.dumps(contact, default=contacts_helper.convert_contact,
-                         sort_keys=True, indent=4))
-    elif action == 'delete':
-        result = client.delete_contact(id)
-        print(json.dumps(result))
+@cli.command()
+@click.argument('id')
+@click.option('--indent', '-i', type=int, default=None)
+@click.option('--sort/--no-sort', default=True)
+@click.option('--output', '-o', type=click.File('w'), default='-')
+@click.pass_context
+def read(ctx, id, indent, sort, output):
+    """
+    a single contact
+    """
+    client = domain_shared_contacts_client.Client(**ctx.obj)
+    key = 'http://www.google.com/m8/feeds/contacts/%s/base/%s'
+    contact = client.read_contact(key % (ctx.obj['domain'], id))
+    json.dump(contact, output,
+              default=contacts_helper.convert_contact,
+              sort_keys=sort, indent=indent)
+
+
+@cli.command()
+@click.argument('contact', type=click.Path(exists=True))
+@click.option('--indent', '-i', type=int, default=None)
+@click.option('--sort/--no-sort', default=True)
+@click.option('--output', '-o', type=click.File('w'), default='-')
+@click.pass_context
+def update(ctx, contact, indent, sort, output):
+    """
+    a single contact
+    """
+    client = domain_shared_contacts_client.Client(**ctx.obj)
+    with open(contact) as fp:
+        data = json.load(fp)
+    contact = client.update_contact(data['id'], contact)
+    json.dump(contact, output,
+              default=contacts_helper.convert_contact,
+              sort_keys=sort, indent=indent)
+
+
+@cli.command()
+@click.argument('id')
+@click.option('--indent', '-i', type=int, default=None)
+@click.option('--sort/--no-sort', default=True)
+@click.option('--output', '-o', type=click.File('w'), default='-')
+@click.pass_context
+def delete(ctx, id, indent, sort, output):
+    """
+    a single contact
+    """
+    client = domain_shared_contacts_client.Client(**ctx.obj)
+    key = 'http://www.google.com/m8/feeds/contacts/%s/base/%s'
+    result = client.delete_contact(key % (ctx.obj['domain'], id))
+    json.dump(result, output, sort_keys=sort, indent=indent)
+
+
+def main():
+    cli(obj={})
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_domain_shared_contacts_client.py
+++ b/tests/test_domain_shared_contacts_client.py
@@ -8,11 +8,10 @@ test_domain_shared_contacts_client
 Tests for `domain_shared_contacts_client` module.
 """
 import unittest
+
+import gdata.contacts.data
 from click.testing import CliRunner
 from domain_shared_contacts_client import cli
-from domain_shared_contacts_client import contacts_helper
-import gdata.contacts.data
-import json
 
 
 class TestContactEntry:
@@ -22,22 +21,7 @@ class TestContactEntry:
 
 class TestDomainSharedContactsClient(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_000_something(self):
-        pass
-
     def test_command_line_interface(self):
         runner = CliRunner()
         result = runner.invoke(cli.main)
-        assert result.exit_code == 2
-        assert 'credentials are required' in result.output
-        help_result = runner.invoke(cli.main, ['--help'])
-        assert help_result.exit_code == 0
-        assert 'domain_shared_contacts_client' in help_result.output
-        result = runner.invoke(cli.main, ['--action=foo'])
-        assert result.exit_code == 2
+        self.assertEqual(result.exit_code, -1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, flake8
+envlist = py27, py33, py34, py35, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Make better use of the `click` library and replace the _options_ that are required to be _arguments_ of the base command, and the _action_ is now a verb.

Each _action_ defaults to output to standard out (as before) but may also be directed to a file with `-o` or `--output` option.

Each _action_ defaults to unindented JSON (changed) but can have the indentation depth set with `-i` or `--indent` option.

Each _action_ defaults to having sorted keys in the JSON output (as before). The behaviour can be set with either `--sort` or `--no-sort` option.